### PR TITLE
Post Daten immer berücksichtigen

### DIFF
--- a/src/ExceptionEnricher/Processor/ExceptionEnricherProcessor.php
+++ b/src/ExceptionEnricher/Processor/ExceptionEnricherProcessor.php
@@ -34,6 +34,8 @@ class ExceptionEnricherProcessor implements ProcessorInterface
                     if (false === empty($postParams)) {
                         $postParams = \serialize($postParams);
                         $record->extra['request_post_data'] = $postParams;
+                    } elseif (!empty($this->requestStack->getCurrentRequest()->getContent())) {
+                        $record->extra['request_post_data'] = $this->requestStack->getCurrentRequest()->getContent();
                     }
                 }
 

--- a/tests/ExceptionEnricher/Processor/ExceptionEnricherProcessorTest.php
+++ b/tests/ExceptionEnricher/Processor/ExceptionEnricherProcessorTest.php
@@ -5,11 +5,12 @@ declare(strict_types=1);
 namespace ExceptionEnricher\Processor;
 
 use DateTimeImmutable;
+use Iterator;
 use Monolog\Level;
 use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\HeaderBag;
-use Symfony\Component\HttpFoundation\ParameterBag;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -90,10 +91,10 @@ class ExceptionEnricherProcessorTest extends TestCase
         $request->method('getRequestUri')->willReturn('/testroute/');
         $request->method('hasSession')->willReturn(true);
 
-        if ($type === 'parameterBag') {
+        if ('inputBag' === $type) {
             $request->request = $data;
         } else {
-            $request->request = new ParameterBag();
+            $request->request = new InputBag();
             $request->method('getContent')->willReturn($data);
         }
 
@@ -125,19 +126,18 @@ class ExceptionEnricherProcessorTest extends TestCase
         $this->assertSame('127.0.0.1', $record->extra['request_ip']);
         $this->assertSame('testuser', $record->extra['username']);
         $this->assertSame('39d9f31fb12441428031e26d2f83ab6e', $record->extra['session_id']);
-        if ($type === 'parameterBag') {
+        if ('inputBag' === $type) {
             $this->assertEquals('a:2:{s:12:"getVariable1";s:6:"value1";s:12:"getVariable2";s:6:"value2";}', $record->extra['request_post_data']);
         } else {
             $this->assertSame('{"getVariable1":"value1","getVariable2":"value2"}', $record->extra['request_post_data']);
         }
     }
 
-    public function providePostRequestData(): \Iterator
+    public function providePostRequestData(): Iterator
     {
-        yield ['parameterBag', new ParameterBag(['getVariable1' => 'value1', 'getVariable2' => 'value2'])];
+        yield ['inputBag', new InputBag(['getVariable1' => 'value1', 'getVariable2' => 'value2'])];
         yield ['content', '{"getVariable1":"value1","getVariable2":"value2"}'];
     }
-
 
     private function createRecord(): LogRecord
     {

--- a/tests/ExceptionEnricher/Processor/ExceptionEnricherProcessorTest.php
+++ b/tests/ExceptionEnricher/Processor/ExceptionEnricherProcessorTest.php
@@ -9,6 +9,7 @@ use Monolog\Level;
 use Monolog\LogRecord;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\HttpFoundation\HeaderBag;
+use Symfony\Component\HttpFoundation\ParameterBag;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\HttpFoundation\Session\SessionInterface;
@@ -37,7 +38,7 @@ class ExceptionEnricherProcessorTest extends TestCase
     /**
      * @covers \ExceptionEnricherProcessor::__invoke
      */
-    public function testFullProcessor()
+    public function testFullProcessorWithGetRequest(): void
     {
         $request = $this->createMock(Request::class);
         $request->headers = new HeaderBag(['User-Agent' => 'Mozilla/5.0']);
@@ -76,6 +77,67 @@ class ExceptionEnricherProcessorTest extends TestCase
         $this->assertSame('testuser', $record->extra['username']);
         $this->assertSame('39d9f31fb12441428031e26d2f83ab6e', $record->extra['session_id']);
     }
+
+    /**
+     * @dataProvider providePostRequestData
+     */
+    public function testFullProcessorWithPostRequest(string $type, $data): void
+    {
+        $request = $this->createMock(Request::class);
+        $request->headers = new HeaderBag(['User-Agent' => 'Mozilla/5.0']);
+        $request->method('getClientIp')->willReturn('127.0.0.1');
+        $request->method('getMethod')->willReturn('POST');
+        $request->method('getRequestUri')->willReturn('/testroute/');
+        $request->method('hasSession')->willReturn(true);
+
+        if ($type === 'parameterBag') {
+            $request->request = $data;
+        } else {
+            $request->request = new ParameterBag();
+            $request->method('getContent')->willReturn($data);
+        }
+
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('getId')->willReturn('39d9f31fb12441428031e26d2f83ab6e');
+
+        $requestStack = $this->createMock(RequestStack::class);
+        $requestStack->method('getCurrentRequest')->willReturn($request);
+        $requestStack->method('getMainRequest')->willReturn($request);
+        $requestStack->method('getSession')->willReturn($session);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUserIdentifier')->willReturn('testuser');
+
+        $tokenStorage = $this->createMock(TokenStorageInterface::class);
+        $tokenStorage->method('getToken')->willReturn($token);
+
+        $exceptionEnricherProcessor = new ExceptionEnricherProcessor($requestStack, $tokenStorage);
+        $record = $exceptionEnricherProcessor($this->createRecord());
+
+        $this->assertArrayHasKey('request_uri', $record->extra);
+        $this->assertArrayHasKey('request_user_agent', $record->extra);
+        $this->assertArrayHasKey('request_ip', $record->extra);
+        $this->assertArrayHasKey('session_id', $record->extra);
+        $this->assertArrayHasKey('username', $record->extra);
+
+        $this->assertSame('POST /testroute/', $record->extra['request_uri']);
+        $this->assertSame('Mozilla/5.0', $record->extra['request_user_agent']);
+        $this->assertSame('127.0.0.1', $record->extra['request_ip']);
+        $this->assertSame('testuser', $record->extra['username']);
+        $this->assertSame('39d9f31fb12441428031e26d2f83ab6e', $record->extra['session_id']);
+        if ($type === 'parameterBag') {
+            $this->assertEquals('a:2:{s:12:"getVariable1";s:6:"value1";s:12:"getVariable2";s:6:"value2";}', $record->extra['request_post_data']);
+        } else {
+            $this->assertSame('{"getVariable1":"value1","getVariable2":"value2"}', $record->extra['request_post_data']);
+        }
+    }
+
+    public function providePostRequestData(): \Iterator
+    {
+        yield ['parameterBag', new ParameterBag(['getVariable1' => 'value1', 'getVariable2' => 'value2'])];
+        yield ['content', '{"getVariable1":"value1","getVariable2":"value2"}'];
+    }
+
 
     private function createRecord(): LogRecord
     {


### PR DESCRIPTION
Aktuell wird der Request Content nicht berücksichtig. Daher fehlen z.B bei GraphQl Requests die Post Daten im Log. 